### PR TITLE
Move toward Python3 compatibility

### DIFF
--- a/examples/grinimports.py
+++ b/examples/grinimports.py
@@ -5,7 +5,12 @@
 
 import compiler
 from compiler.visitor import ASTVisitor, walk
-from cStringIO import StringIO
+try:
+    # Python 2
+    from StringIO import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
 import os
 import shlex
 import sys

--- a/examples/grinpython.py
+++ b/examples/grinpython.py
@@ -3,7 +3,13 @@
 """ Transform Python code by omitting strings, comments, and/or code.
 """
 
-from cStringIO import StringIO
+
+try:
+    # Python 2
+    from StringIO import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
 import os
 import shlex
 import string

--- a/grin.py
+++ b/grin.py
@@ -245,7 +245,19 @@ class GrepText(object):
         else:
             remaining = max(fp_size - fp.tell(), 0)
             target_io_size = min(READ_BLOCKSIZE, remaining)
-            block_main = fp.read(target_io_size)
+            try:
+                block_main = fp.read(target_io_size)
+            except:
+                (except_type,except_value,except_traceback) = sys.exc_info()
+                print('{}\n{}'.format('Detected unreadable character. Here are error details:', str(except_value)))
+                result = DataBlock(
+                    data = '',
+                    start = 0,
+                    end = 0,
+                    before_count = 0,
+                    is_last = True
+                )
+                return result
             is_last_block = target_io_size == remaining
 
         if prev is None:


### PR DESCRIPTION
Conditional imports for StringIO.

Try-Except bailout when Python3 encounters unreadable character.